### PR TITLE
Remove 'Tool' from VScode command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ format-types will be added. Feel free to enter feature-requests.
 
 ## Features
 
-The tool is available via the Command-Palette. Just type `cmnd+shift+p` and enter `openHAB Alignment Tool`. Then you get the option to format the whole file.
+The tool is available via the Command-Palette. Just type `cmnd+shift+p` and enter `openHAB Alignment`. Then you get the option to format the whole file.
 
 ### Item-Formatting:
 


### PR DESCRIPTION
It looks like there was a change in the name of the commands.

![image](https://user-images.githubusercontent.com/1270359/80862479-cc9b1800-8c75-11ea-974f-c7ca6ae7e230.png)

![image](https://user-images.githubusercontent.com/1270359/80862483-cefd7200-8c75-11ea-9d92-17a2b06e11a2.png)
